### PR TITLE
feat: 添加全局快捷键支持 (Issue #1)

### DIFF
--- a/code/src/App.tsx
+++ b/code/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { PanelLeftOpen, GitBranch } from 'lucide-react'
 import { Header } from './components/layout'
 import { Main } from './components/layout'
@@ -10,6 +10,7 @@ import { DiffSidebar } from './components/DiffSidebar'
 import { useWorktreeStore } from './stores/worktreeStore'
 import { useRepositoryStore } from './stores/repositoryStore'
 import { settingsStore } from './stores/settingsStore'
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import type { RepositoryInfo } from './types/worktree'
 
 function App() {
@@ -20,6 +21,35 @@ function App() {
   const [showSettings, setShowSettings] = useState(false)
   const [diffWorktree, setDiffWorktree] = useState<{ path: string; name: string } | null>(null)
   const [mainCollapsed, setMainCollapsed] = useState(() => localStorage.getItem('main-panel-collapsed') === 'true')
+  
+  // 搜索框 ref
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  
+  // 聚焦搜索框
+  const focusSearch = useCallback(() => {
+    searchInputRef.current?.focus()
+  }, [])
+  
+  // 关闭所有对话框
+  const closeAllDialogs = useCallback(() => {
+    if (showCreateDialog) {
+      setShowCreateDialog(false)
+    } else if (showSettings) {
+      setShowSettings(false)
+    } else if (diffWorktree) {
+      setDiffWorktree(null)
+    }
+  }, [showCreateDialog, showSettings, diffWorktree])
+
+  // 注册快捷键
+  useKeyboardShortcuts({
+    onCreateWorktree: () => setShowCreateDialog(true),
+    onRefresh: refreshWorktrees,
+    onOpenSettings: () => setShowSettings(true),
+    onFocusSearch: focusSearch,
+    onCloseDialog: closeAllDialogs,
+    enabled: !mainCollapsed && !!currentRepo,
+  })
 
   const toggleMainCollapsed = () => {
     setMainCollapsed(prev => {
@@ -101,6 +131,7 @@ function App() {
               onCreateWorktree={() => setShowCreateDialog(true)}
               onShowDiff={(path, name) => setDiffWorktree({ path, name })}
               onCollapse={toggleMainCollapsed}
+              searchInputRef={searchInputRef}
             />
           )}
 

--- a/code/src/components/WorktreeList/index.tsx
+++ b/code/src/components/WorktreeList/index.tsx
@@ -15,9 +15,10 @@ interface WorktreeListProps {
   onCreateWorktree?: () => void
   onShowDiff?: (path: string, name: string) => void
   onCollapse?: () => void
+  searchInputRef?: React.RefObject<HTMLInputElement>
 }
 
-export function WorktreeList({ onCreateWorktree, onShowDiff, onCollapse }: WorktreeListProps) {
+export function WorktreeList({ onCreateWorktree, onShowDiff, onCollapse, searchInputRef }: WorktreeListProps) {
   const { worktrees, isLoading, currentRepo, refreshWorktrees } = useWorktreeStore()
   const [searchQuery, setSearchQuery] = useState('')
   const [sortField, setSortField] = useState<SortField>('name')
@@ -119,6 +120,7 @@ export function WorktreeList({ onCreateWorktree, onShowDiff, onCollapse }: Workt
           <div className="relative flex-shrink min-w-[120px]">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
             <input
+              ref={searchInputRef}
               type="text"
               placeholder="搜索分支名、路径..."
               value={searchQuery}

--- a/code/src/hooks/useKeyboardShortcuts.ts
+++ b/code/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,97 @@
+import { useEffect, useCallback, useRef } from 'react'
+
+interface KeyboardShortcutsConfig {
+  onCreateWorktree: () => void
+  onRefresh: () => void
+  onOpenSettings: () => void
+  onFocusSearch: () => void
+  onCloseDialog: () => void
+  onDeleteSelected?: () => void
+  enabled?: boolean
+}
+
+/**
+ * 全局快捷键 Hook
+ * 
+ * 快捷键映射：
+ * - Cmd/Ctrl + N: 创建新 worktree
+ * - Cmd/Ctrl + R: 刷新 worktree 列表
+ * - Cmd/Ctrl + F: 聚焦搜索框
+ * - Cmd/Ctrl + ,: 打开设置
+ * - Escape: 关闭对话框/取消操作
+ */
+export function useKeyboardShortcuts({
+  onCreateWorktree,
+  onRefresh,
+  onOpenSettings,
+  onFocusSearch,
+  onCloseDialog,
+  onDeleteSelected,
+  enabled = true,
+}: KeyboardShortcutsConfig) {
+  const isDialogOpen = useRef(false)
+
+  // 设置对话框状态（供外部组件调用）
+  const setDialogOpen = useCallback((open: boolean) => {
+    isDialogOpen.current = open
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+      const cmdKey = isMac ? e.metaKey : e.ctrlKey
+
+      // Escape - 关闭对话框（优先级最高）
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCloseDialog()
+        return
+      }
+
+      // 以下快捷键在有对话框打开时不触发
+      if (isDialogOpen.current) return
+
+      // Cmd/Ctrl + N - 创建新 worktree
+      if (cmdKey && e.key === 'n') {
+        e.preventDefault()
+        onCreateWorktree()
+        return
+      }
+
+      // Cmd/Ctrl + R - 刷新列表
+      if (cmdKey && e.key === 'r') {
+        e.preventDefault()
+        onRefresh()
+        return
+      }
+
+      // Cmd/Ctrl + F - 聚焦搜索框
+      if (cmdKey && e.key === 'f') {
+        e.preventDefault()
+        onFocusSearch()
+        return
+      }
+
+      // Cmd/Ctrl + , - 打开设置
+      if (cmdKey && e.key === ',') {
+        e.preventDefault()
+        onOpenSettings()
+        return
+      }
+
+      // Delete - 删除选中的 worktree（可选）
+      if (e.key === 'Delete' && onDeleteSelected) {
+        e.preventDefault()
+        onDeleteSelected()
+        return
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [enabled, onCreateWorktree, onRefresh, onOpenSettings, onFocusSearch, onCloseDialog, onDeleteSelected])
+
+  return { setDialogOpen }
+}


### PR DESCRIPTION
## 功能描述

实现 Issue #1 - 支持快捷键操作

### 已实现的快捷键

| 快捷键 | 功能 | 状态 |
|--------|------|------|
| `Cmd/Ctrl + N` | 创建新 worktree | ✅ |
| `Cmd/Ctrl + R` | 刷新 worktree 列表 | ✅ |
| `Cmd/Ctrl + F` | 聚焦搜索框 | ✅ |
| `Cmd/Ctrl + ,` | 打开设置 | ✅ |
| `Escape` | 关闭对话框/取消操作 | ✅ |

### 待实现功能

- [ ] `Cmd/Ctrl + Delete`: 删除选中的 worktree（需要先实现选中状态）
- [ ] 快捷键可在设置中自定义
- [ ] 快捷键不与系统快捷键冲突

### 变更说明

1. 新增 `useKeyboardShortcuts` hook 处理全局快捷键
2. 修改 `App.tsx` 集成快捷键功能
3. 修改 `WorktreeList` 支持外部 searchInputRef

### 测试方法

1. 启动应用
2. 添加一个仓库
3. 测试各个快捷键功能：
   - 按 `Cmd+N` 应该弹出创建对话框
   - 按 `Cmd+R` 应该刷新列表
   - 按 `Cmd+F` 应该聚焦搜索框
   - 按 `Cmd+,` 应该打开设置
   - 按 `Escape` 应该关闭当前对话框