### PR TITLE
feat: 显示远程同步状态 (Issue #3)

### DIFF
--- a/code/src-tauri/src/models/worktree.rs
+++ b/code/src-tauri/src/models/worktree.rs
@@ -17,6 +17,28 @@ pub enum WorktreeStatus {
     Unknown,
 }
 
+/// 远程同步状态
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncStatus {
+    /// 领先远程的提交数
+    pub ahead: usize,
+    /// 落后远程的提交数
+    pub behind: usize,
+    /// 是否有远程分支
+    pub has_remote: bool,
+}
+
+impl Default for SyncStatus {
+    fn default() -> Self {
+        SyncStatus {
+            ahead: 0,
+            behind: 0,
+            has_remote: false,
+        }
+    }
+}
+
 /// 最后提交信息
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -53,6 +75,8 @@ pub struct Worktree {
     pub is_main: bool,
     /// 关联的远程仓库
     pub remote: Option<String>,
+    /// 远程同步状态
+    pub sync_status: SyncStatus,
 }
 
 /// 创建 Worktree 参数

--- a/code/src-tauri/src/services/git_service.rs
+++ b/code/src-tauri/src/services/git_service.rs
@@ -1,4 +1,4 @@
-use crate::models::{CreateWorktreeParams, Worktree, WorktreeListResponse, WorktreeResult, WorktreeStatus, Branch, BranchListResponse, LastCommit, DiffStats, DiffResponse, DiffLine, DiffHunk, FileDiff, DetailedDiffResponse, RepositoryInfo, SwitchBranchResult, BatchDeleteResult, WorktreeHint};
+use crate::models::{CreateWorktreeParams, Worktree, WorktreeListResponse, WorktreeResult, WorktreeStatus, Branch, BranchListResponse, LastCommit, DiffStats, DiffResponse, DiffLine, DiffHunk, FileDiff, DetailedDiffResponse, RepositoryInfo, SwitchBranchResult, BatchDeleteResult, WorktreeHint, SyncStatus};
 use crate::utils::validation::{sanitize_branch_name, validate_path};
 use git2::Repository;
 use std::path::Path;
@@ -48,6 +48,7 @@ fn get_main_worktree(repo: &Repository) -> anyhow::Result<Worktree> {
     let commit = head.peel_to_commit()?;
     let status = get_worktree_status(repo)?;
     let last_commit = get_last_commit(&commit)?;
+    let sync_status = get_sync_status(repo, &branch)?;
 
     Ok(Worktree {
         id: commit.id().to_string(),
@@ -59,6 +60,7 @@ fn get_main_worktree(repo: &Repository) -> anyhow::Result<Worktree> {
         last_active_at: None,
         is_main: true,
         remote: None,
+        sync_status,
     })
 }
 
@@ -74,6 +76,7 @@ fn get_linked_worktree(repo: &Repository, name: &str) -> anyhow::Result<Option<W
     let commit = head.peel_to_commit()?;
     let status = get_worktree_status(&wt_repo)?;
     let last_commit = get_last_commit(&commit)?;
+    let sync_status = get_sync_status(&wt_repo, &branch)?;
 
     Ok(Some(Worktree {
         id: commit.id().to_string(),
@@ -85,6 +88,7 @@ fn get_linked_worktree(repo: &Repository, name: &str) -> anyhow::Result<Option<W
         last_active_at: None,
         is_main: false,
         remote: None,
+        sync_status,
     }))
 }
 
@@ -129,6 +133,40 @@ fn format_relative_time(now: i64, commit_time: i64) -> String {
         format!("{} 月前", diff / 2592000)
     } else {
         format!("{} 年前", diff / 31536000)
+    }
+}
+
+/// 获取 worktree 与远程分支的同步状态
+fn get_sync_status(repo: &Repository, branch_name: &str) -> anyhow::Result<SyncStatus> {
+    // 获取本地分支的 HEAD
+    let head = repo.head()?;
+    let local_commit = head.peel_to_commit()?;
+
+    // 查找远程分支
+    let remote_branch_name = format!("origin/{}", branch_name);
+    let remote_ref_name = format!("refs/remotes/{}", remote_branch_name);
+
+    match repo.find_reference(&remote_ref_name) {
+        Ok(remote_ref) => {
+            let remote_commit = remote_ref.peel_to_commit()?;
+
+            // 计算 ahead/behind
+            let (ahead, behind) = repo.graph_ahead_behind(local_commit.id(), remote_commit.id())?;
+
+            Ok(SyncStatus {
+                ahead,
+                behind,
+                has_remote: true,
+            })
+        }
+        Err(_) => {
+            // 没有远程分支
+            Ok(SyncStatus {
+                ahead: 0,
+                behind: 0,
+                has_remote: false,
+            })
+        }
     }
 }
 

--- a/code/src/components/WorktreeList/WorktreeItem.tsx
+++ b/code/src/components/WorktreeList/WorktreeItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Worktree } from '@/types/worktree'
 import { StatusBadge } from './StatusBadge'
-import { Folder, ExternalLink, Terminal, Trash2, GitCompare, GitBranch } from 'lucide-react'
+import { Folder, ExternalLink, Terminal, Trash2, GitCompare, GitBranch, ArrowUp, ArrowDown, Check } from 'lucide-react'
 import { gitService } from '@/services/git'
 import { useWorktreeStore } from '@/stores/worktreeStore'
 import { settingsStore } from '@/stores/settingsStore'
@@ -88,6 +88,50 @@ export function WorktreeItem({ worktree, branches, onShowDiff }: WorktreeItemPro
                 <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded">
                   Main
                 </span>
+              )}
+              {/* 同步状态 */}
+              {worktree.syncStatus && worktree.syncStatus.hasRemote && (
+                <div className="flex items-center gap-1 text-xs">
+                  {worktree.syncStatus.ahead > 0 && (
+                    <span
+                      className="flex items-center gap-0.5 text-green-600 dark:text-green-400 cursor-pointer hover:underline"
+                      title={`${worktree.syncStatus.ahead} 个提交未推送`}
+                      onClick={async () => {
+                        try {
+                          // TODO: 实现 push 功能
+                          console.log('Push', worktree.syncStatus?.ahead, 'commits')
+                        } catch (error) {
+                          console.error('Push failed:', error)
+                        }
+                      }}
+                    >
+                      <ArrowUp className="w-3 h-3" />
+                      {worktree.syncStatus.ahead}
+                    </span>
+                  )}
+                  {worktree.syncStatus.behind > 0 && (
+                    <span
+                      className="flex items-center gap-0.5 text-orange-600 dark:text-orange-400 cursor-pointer hover:underline"
+                      title={`${worktree.syncStatus.behind} 个提交未拉取`}
+                      onClick={async () => {
+                        try {
+                          // TODO: 实现 pull 功能
+                          console.log('Pull', worktree.syncStatus?.behind, 'commits')
+                        } catch (error) {
+                          console.error('Pull failed:', error)
+                        }
+                      }}
+                    >
+                      <ArrowDown className="w-3 h-3" />
+                      {worktree.syncStatus.behind}
+                    </span>
+                  )}
+                  {worktree.syncStatus.ahead === 0 && worktree.syncStatus.behind === 0 && (
+                    <span className="flex items-center gap-0.5 text-gray-400 dark:text-gray-500" title="与远程同步">
+                      <Check className="w-3 h-3" />
+                    </span>
+                  )}
+                </div>
               )}
             </div>
 

--- a/code/src/types/worktree.ts
+++ b/code/src/types/worktree.ts
@@ -17,6 +17,18 @@ export enum WorktreeStatus {
 }
 
 /**
+ * 远程同步状态
+ */
+export interface SyncStatus {
+  /** 领先远程的提交数 */
+  ahead: number
+  /** 落后远程的提交数 */
+  behind: number
+  /** 是否有远程分支 */
+  hasRemote: boolean
+}
+
+/**
  * 最后提交信息
  */
 export interface LastCommit {
@@ -54,6 +66,8 @@ export interface Worktree {
   remote?: string
   /** 额外元数据 */
   metadata?: Record<string, unknown>
+  /** 远程同步状态 */
+  syncStatus: SyncStatus
 }
 
 /**


### PR DESCRIPTION
## 功能描述

实现 Issue #3 - 显示远程同步状态

### 已实现功能

- ✅ 显示 ahead/behind 提交数量
- ✅ 点击可触发 push/pull 操作（待实现完整功能）
- ✅ 无差异时显示 ✓ 标记
- ✅ 无远程分支时优雅处理

### UI 展示

| 状态 | 显示 |
|------|------|
| 领先远程 | 🟢 ↑ 3 |
| 落后远程 | 🟠 ↓ 2 |
| 同步 | ✓ |
| 无远程 | 不显示 |

### 变更说明

1. **后端**
   - 添加 `SyncStatus` 结构体
   - 新增 `get_sync_status` 函数获取 ahead/behind 信息
   - 修改 `Worktree` 模型添加 `sync_status` 字段

2. **前端**
   - 更新 TypeScript 类型定义
   - `WorktreeItem` 组件显示同步状态指示器

### 待实现

- [ ] 点击 ahead 数量执行 push
- [ ] 点击 behind 数量执行 pull
- [ ] 定时刷新远程状态